### PR TITLE
[REFACTOR] Messages Stream

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -25,7 +25,7 @@ plugins:
         - about
         - stream-maps
       config:
-        start_date: "2010-01-01T00:00:00Z"
+        start_date: "2023-04-04"
       settings:
         - name: api_key
           label: API Key

--- a/tap_kustomer/streams/__init__.py
+++ b/tap_kustomer/streams/__init__.py
@@ -38,11 +38,6 @@ from tap_kustomer.streams.customer_streams import (
 
 from tap_kustomer.streams.message_streams import (
     MessagesStream,
-    MessageAssignedTeamStream,
-    MessageAssignedUserStream,
-    MessageAttachmentStream,
-    MessageCreatedByTeamStream,
-    MessageShortcutStream,
 )
 
 from tap_kustomer.streams.note_streams import (

--- a/tap_kustomer/streams/message_streams.py
+++ b/tap_kustomer/streams/message_streams.py
@@ -1,22 +1,12 @@
-
 from __future__ import annotations
-
-from pathlib import Path
 
 from tap_kustomer.client import kustomerStream
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
-SCHEMAS_DIR = Path(__file__).parent / "schemas" / "message"
-
 # Streams to export
 __all__ = [
-    "MessagesStream",
-	"MessageAssignedTeamStream",
-	"MessageAssignedUserStream",
-	"MessageAttachmentStream",
-	"MessageCreatedByTeamStream",
-	"MessageShortcutStream"
+    "MessagesStream"
 ]
 
     
@@ -26,12 +16,19 @@ class MessagesStream(kustomerStream):
     """
 
     name = "messages"
-    path = "messages"
-    primary_keys = []
-    replication_key = "id"
+    path = "customers/search"
+    rest_method = "POST"
+    primary_keys = ["id"]
+    replication_key = "updated_at"
     records_jsonpath = "$[data][*]"
 
+    max_observed_timestamp = None
+    max_timestamp = None
+    updated_at = "message_updated_at"
+    query_context = "message"
+
     schema = th.PropertiesList(
+        th.Property("updated_at", th.DateTimeType, description=""),
         th.Property("type", th.StringType, description=""),
         th.Property("id", th.StringType, description=""),
         th.Property("attributes", 
@@ -42,65 +39,6 @@ class MessagesStream(kustomerStream):
                 th.Property("size", th.NumberType, description=""),
                 th.Property("direction", th.StringType, description=""),
                 th.Property("preview", th.StringType, description=""),
-                # th.Property("sentiment", th.ObjectType(th.StringType), description=""),
+                th.Property("status", th.StringType, description=""),
+                th.Property("assignedTeams", th.ArrayType(th.StringType), description=""),
         ))).to_dict()
-
-class MessageAssignedTeamStream(kustomerStream):
-    """
-    TODO
-    """
-
-    name = "message_assigned_team"
-    path = "/v1/TODO"
-    primary_keys = ["TODO"]
-    replication_key = "TODO"
-    schema_filepath = SCHEMAS_DIR / "message_assigned_team.json"
-
-
-class MessageAssignedUserStream(kustomerStream):
-    """
-    TODO
-    """
-
-    name = "message_assigned_user"
-    path = "/v1/TODO"
-    primary_keys = ["TODO"]
-    replication_key = "TODO"
-    schema_filepath = SCHEMAS_DIR / "message_assigned_user.json"
-
-
-class MessageAttachmentStream(kustomerStream):
-    """
-    TODO
-    """
-
-    name = "message_attachment"
-    path = "/v1/TODO"
-    primary_keys = ["TODO"]
-    replication_key = "TODO"
-    schema_filepath = SCHEMAS_DIR / "message_attachment.json"
-
-
-class MessageCreatedByTeamStream(kustomerStream):
-    """
-    TODO
-    """
-
-    name = "message_created_by_team"
-    path = "/v1/TODO"
-    primary_keys = ["TODO"]
-    replication_key = "TODO"
-    schema_filepath = SCHEMAS_DIR / "message_created_by_team.json"
-
-
-class MessageShortcutStream(kustomerStream):
-    """
-    TODO
-    """
-
-    name = "message_shortcut"
-    path = "/v1/TODO"
-    primary_keys = ["TODO"]
-    replication_key = "TODO"
-    schema_filepath = SCHEMAS_DIR / "message_shortcut.json"
-


### PR DESCRIPTION
- This PR refactors the messages stream to use the `/customers/search` endpoint. Documentation on this endpoint [can be found here.](https://developer.kustomer.com/kustomer-api-docs/reference/customersearch)
- This PR alters the base logic of the tap to meet the nuances of this endpoint which it does by:
    - Adding a new client method `prepare_request_payload`
    - Setting a `max_observed_timestamp` 
    - When the `next_page_token` is page 101. Resets the page to 1 and passes the `max_observed_timestamp` in the stream context.